### PR TITLE
Change period to colon on line 25

### DIFF
--- a/2_soul_food/README.md
+++ b/2_soul_food/README.md
@@ -31,7 +31,7 @@ you can’t refuse them.
 
 To bear and not to own;  
 to act and not lay claim;  
-to do the work and let it go.  
+to do the work and let it go:  
 for just letting it go  
 is what makes it stay.  
 


### PR DESCRIPTION
This is how it appears in my copy of the book, which is the 6th printing, copyright 1997. I believe that there is only one edition, although the cover has changed several times - the 6th printing seems to be from 2019 or later, since that's when the cover copyright is. I haven't found any evidence of a earlier edition without the colon here.

I have retained the two spaces after the line, for conformity with the other lines in the file.